### PR TITLE
[Bug] - Transactions were being created with Tag ids

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,6 @@ source 'https://rubygems.org' do
     gem 'rack-test'
     gem 'rspec'
     gem 'rubocop'
+    gem 'hypothesis-specs', '0.6.0'
   end
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,9 @@ GEM
       dry-equalizer (~> 0.3)
       dry-inflector (~> 0.1, >= 0.1.2)
       dry-logic (~> 1.0, >= 1.0.2)
+    hypothesis-specs (0.6.0)
+      rake (>= 10.0, < 13.0)
+      rutie (~> 0.0.3)
     ice_nine (0.11.2)
     method_source (1.0.0)
     mustermann (1.1.1)
@@ -55,6 +58,7 @@ GEM
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rainbow (3.0.0)
+    rake (12.3.3)
     regexp_parser (1.7.1)
     rexml (3.2.4)
     rspec (3.9.0)
@@ -83,6 +87,7 @@ GEM
       parser (>= 2.7.1.4)
     ruby-progressbar (1.10.1)
     ruby2_keywords (0.0.2)
+    rutie (0.0.4)
     sequel (5.35.0)
     sexpr (0.6.0)
     sinatra (2.0.8.1)
@@ -99,6 +104,7 @@ PLATFORMS
 DEPENDENCIES
   bmg!
   dry-struct!
+  hypothesis-specs (= 0.6.0)!
   pg!
   pry!
   rack-test!

--- a/spec/test_hypothesis_spec.rb
+++ b/spec/test_hypothesis_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require_relative 'test_application'
+require 'hypothesis'
+
+describe 'Hypothesis' do
+  include Hypothesis
+  include Hypothesis::Possibilities
+
+  specify do
+    x = 0
+    hypothesis(max_valid_test_cases: 1_000) do
+      puts "Iteration: #{x}"
+      x += 1
+      puts;puts;
+      puts "---- Start block ----"
+
+      test_app = test_application
+
+      actions = [:create_account, :create_transaction, :create_tag]
+      indexes = any arrays(of: integers(min: 0, max: actions.length - 1), max_size: 100), name: 'Action indexes'
+
+      indexes.each do |i|
+        puts "Performing: #{actions[i]}"
+
+        case actions[i]
+        when :create_account
+          account_name = any strings, name: 'Account Name'
+          test_app.create_account(account_name)
+        when :create_transaction
+          next if test_app.accounts.empty?
+          account = any element_of(test_app.accounts), name: 'Transaction Account'
+          amount = any integers(min: 1, max: 500), name: 'Transaction Amount'
+          test_app.create_transaction(
+            name: any(strings),
+            account_id: account.id,
+            amount: amount.to_f,
+            currency: :usd,
+            day_of_month: any(integers(min: 1, max: 31))
+          )
+        when :create_tag
+          next if test_app.transactions.empty?
+
+          transaction = any(element_of(test_app.transactions))
+          test_app.tag_transaction(transaction.id, tag: any(strings))
+        end
+      end
+
+      max_count = if test_app.transaction_tags.count == 0
+          2
+      else
+        test_app.transaction_tags.count
+      end
+      tag_sample_count = any integers(min: 1, max: max_count)
+      possible_tags = test_app.transaction_tags.sample(tag_sample_count).map(&:name)
+
+      puts "Sampled #{tag_sample_count} tags: #{possible_tags}"
+
+      filtered_transactions = test_app.use_cases[:transactions].transactions_for_tags(possible_tags, nil)
+      puts "Got #{filtered_transactions.count} filtered transactions"
+
+      filtered_transactions.each do |transaction|
+        transaction_tags = test_app.tag_index[transaction.id]
+
+        expect(transaction_tags).to_not be_nil
+
+        tags = transaction_tags.map(&:name)
+        same_tags = tags & possible_tags
+        expect(same_tags.length).to be > 0
+      end
+    end
+  end
+end


### PR DESCRIPTION
Our query strategy here is to join tags and transactions. First, transactions.id is renamed to transactions.transaction_id so we can do a natural join. This means that when we construct a Transaction type from this result relation, the id attribute is actually a Tag id.

This can be avoided by first renaming tags.id to tags.tag_id, joining, and then renaming transactions.transaction_id to transactions.id on the result. A little tricky, but this ensures that Transactions are created with their proper ids.

Reproduced this bug with a property-based test that strictly uses the Application API to create and query data (one exception was calling a use case method directly, since the Application API is still under a bit of construction). Instead of generating complex data, we generate sequences of API calls and perform them. This feels like a good pattern for the future.