### PR TITLE
Support specifying when the transaction occurs.

### DIFF
--- a/postgres/setup.rb
+++ b/postgres/setup.rb
@@ -27,7 +27,7 @@ DB.create_table :transactions do
   String :currency
   String :name
   String :recurrence_rule
-  DateTime :created_at
+  Date :occurs_on
 end
 
 DB.create_table :transaction_tags do

--- a/spec/generative/actions.rb
+++ b/spec/generative/actions.rb
@@ -30,16 +30,20 @@ module ApplicationActions
       month_day = any integers(min: 1, max: 31)
       week_day = any element_of(%w[MO TU WE TH FR SA SU])
       rrule = any element_of([
-                               "FREQ=MONTHLY;BYMONTHDAY=#{month_day}",
-                               "FREQ=WEEKLY;BYDAY=#{week_day}"
-                             ])
+                              "FREQ=MONTHLY;BYMONTHDAY=#{month_day}",
+                              "FREQ=WEEKLY;BYDAY=#{week_day}"
+                            ])
+
+      date_offset = any integers(min: -500, max: 500)
+      occurs_on = Date.today + date_offset
 
       test_app.create_transaction(
         name: any(strings),
         account_id: account.id,
         amount: amount.to_f,
         currency: :usd,
-        recurrence_rule: rrule
+        recurrence_rule: rrule,
+        occurs_on: occurs_on
       )
     when :create_tag
       return if test_app.all_transactions.transactions.empty?

--- a/types.rb
+++ b/types.rb
@@ -34,12 +34,12 @@ class PlannedTransaction < Dry::Struct
   attribute :name, Types::String
   attribute :currency, Types::Value(:usd)
   attribute :recurrence_rule, Types::String
-  attribute :created_at, Types.Constructor(DateTime) { |created_at| created_at }
+  attribute :occurs_on, Types.Constructor(Date) { |occurs_on| occurs_on }
 
   def occurrences_within(period)
     start_date = period.begin.to_time
 
-    RRule.parse(recurrence_rule, dtstart: created_at, tzid: Time.now.getlocal.zone).between(
+    RRule.parse(recurrence_rule, dtstart: occurs_on.to_time, tzid: Time.now.getlocal.zone).between(
       start_date,
       period.end.to_time
     )

--- a/web_server/views/transaction_form.erb
+++ b/web_server/views/transaction_form.erb
@@ -34,6 +34,11 @@
       <input class="input"name="recurrence_rule" type="text" />
     </div>
 
+    <div class="field">
+      <label class="label" for="occurs_on">Occurs on</label>
+      <input class="input"name="occurs_on" type="date" />
+    </div>
+
     <button class="button is-primary" type="submit">Create Transaction</input>
   </form>
 </div>


### PR DESCRIPTION
Consider a biweekly payment. We need to know the week that it occurs on to correctly determine which days it should fall on in the future